### PR TITLE
Provide a default in case the usernames role variable is unspecified

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,3 +3,7 @@
 package_names:
   - curl
   - python3-lxml
+
+# The users for whom a symlink to the COOL file share should be
+# created.
+usernames: []

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,3 +3,7 @@
 package_names:
   - curl
   - python3-lxml
+
+# The users for whom a symlink to the COOL file share should be
+# created.
+usernames: []


### PR DESCRIPTION
## 🗣 Description ##

Provide a default in case the `usernames` role variable is unspecified.  The default value is simply an empty list.

## 💭 Motivation and context ##

This makes the role backwards compatible for other code that was using the role before #27.  This should have been done in #27 but was forgotten.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.
