### PR TITLE
Move the usernames role variable from vars to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,7 @@
 # The version of the JetBrainsMono font to download from
 # https://github.com/JetBrains/JetBrainsMono
 jetbrainsmono_version: "2.241"
+
+# The users for whom a symlink to the COOL file share should be
+# created.
+usernames: []

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,7 +3,3 @@
 package_names:
   - curl
   - python3-lxml
-
-# The users for whom a symlink to the COOL file share should be
-# created.
-usernames: []

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,7 +3,3 @@
 package_names:
   - curl
   - python3-lxml
-
-# The users for whom a symlink to the COOL file share should be
-# created.
-usernames: []


### PR DESCRIPTION
## 🗣 Description ##

This pull request moves the `usernames` role variable from `vars` to `defaults`.

## 💭 Motivation and context ##

Variables in `vars` are difficult to override, while those in `defaults` are easily overridden.  I must have suffered a mild stroke when I added this variable to `vars`, since that was a bone-headed thing to do.  Or perhaps I am just a fool.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also verified that this change fixes the issue I was seeing when building COOL AMIs where the desktop shortcut to the EFS share was not being created.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
