### PR TITLE
Fix comment tags that are incorrectly closed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 ---
 
+# Any ignore directives should be uncommented in downstream projects to disable
+# Dependabot updates for the given dependency. Downstream projects will get
+# these updates when the pull request(s) in the appropriate skeleton are merged
+# and Lineage processes these changes.
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # ignore:
-    #   - dependency-name: "ansible"
-    #   - dependency-name: "ansible-lint"
+    ignore:
+      - dependency-name: "ansible"
+      - dependency-name: "ansible-lint"
 
   - package-ecosystem: "terraform"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # ignore:
-    #   - dependency-name: actions/cache
-    #   - dependency-name: actions/checkout
-    #   - dependency-name: actions/setup-python
+    ignore:
+      - dependency-name: actions/cache
+      - dependency-name: actions/checkout
+      - dependency-name: actions/setup-python
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # ignore:
+    #   - dependency-name: "ansible"
+    #   - dependency-name: "ansible-lint"
 
   - package-ecosystem: "terraform"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # ignore:
+    #   - dependency-name: actions/cache
+    #   - dependency-name: actions/checkout
+    #   - dependency-name: actions/setup-python
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         id: go-cache
         run: |
           echo "::set-output name=dir::$(go env GOCACHE)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         env:
           BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v2
       - id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       # We need the Go version and Go cache location for the actions/cache step,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: setup-env
         uses: cisagov/setup-env-github-action@develop
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: setup-python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
       # We need the Go version and Go cache location for the actions/cache step,
       # so the Go installation must happen before that.
       - uses: actions/setup-go@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       # so the Go installation must happen before that.
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: "1.16"
       - name: Store installed Go version
         id: go-version
         run: |

--- a/.mdl_config.yaml
+++ b/.mdl_config.yaml
@@ -48,3 +48,13 @@ MD035:
 MD046:
   # Enforce the fenced style for code blocks
   style: "fenced"
+
+# MD049/emphasis-style - Emphasis style should be consistent
+MD049:
+  # Enforce asterisks as the style to use for emphasis
+  style: "asterisk"
+
+# MD050/strong-style - Strong style should be consistent
+MD050:
+  # Enforce asterisks as the style to use for strong
+  style: "asterisk"

--- a/.mdl_config.yaml
+++ b/.mdl_config.yaml
@@ -44,7 +44,7 @@ MD035:
   # Enforce dashes for horizontal rules
   style: "---"
 
-# MD046/code-block-style Code block style
+# MD046/code-block-style - Code block style
 MD046:
   # Enforce the fenced style for code blocks
   style: "fenced"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
   # Text file hooks
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.30.0
+    rev: v0.31.1
     hooks:
       - id: markdownlint
         args:
@@ -49,7 +49,7 @@ repos:
 
   # pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: validate_manifest
 
@@ -75,13 +75,13 @@ repos:
 
   # Python hooks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.1
+    rev: 1.7.2
     hooks:
       - id: bandit
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -105,14 +105,14 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v5.3.2
+    rev: v5.4.0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.64.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,13 @@ repos:
         args:
           - --strict
 
+  # GitHub Actions hooks
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.14.2
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+
   # pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit
     rev: v2.17.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         args:
           - --config=.mdl_config.yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.1
     hooks:
       - id: prettier
   - repo: https://github.com/adrienverge/yamllint
@@ -75,13 +75,13 @@ repos:
 
   # Python hooks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.2
+    rev: 1.7.4
     hooks:
       - id: bandit
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -95,11 +95,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.942
     hooks:
       - id: mypy
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
 
@@ -119,7 +119,7 @@ repos:
 
   # Docker hooks
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v2.0.1
+    rev: v2.1.0
     hooks:
       - id: docker-compose-check
 

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,12 @@
 extends: default
 
 rules:
+  # yamllint does not like it when you comment out different parts of
+  # dictionaries in a list. You can see
+  # https://github.com/adrienverge/yamllint/issues/384 for some examples of
+  # this behavior.
+  comments-indentation: disable
+
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,9 +28,8 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - 32
-        - 33
         - 34
+        - 35
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -29,12 +29,10 @@ platforms:
     image: debian:bookworm-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora32
-    image: fedora:32
-  - name: fedora33
-    image: fedora:33
   - name: fedora34
     image: fedora:34
+  - name: fedora35
+    image: fedora:35
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -57,22 +57,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora32-systemd
-    image: geerlingguy/docker-fedora32-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-  - name: fedora33-systemd
-    image: geerlingguy/docker-fedora33-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
   - name: fedora34-systemd
     image: geerlingguy/docker-fedora34-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora35-systemd
+    image: geerlingguy/docker-fedora35-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -96,7 +96,7 @@ provisioner:
   name: ansible
   inventory:
     host_vars:
-      debian9_systemd:
+      debian9-systemd:
         # auto_legacy is still the default behavior until Ansible 2.12
         # is released, but Molecule overrides this and forces the use
         # of auto.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,22 @@
 
 - name: Set clock format to UTC
   block:
+    # The file /etc/xdg/xfce4/panel/default.xml sometimes contains
+    # comment tags that are closed incorrectly.  In particular, a
+    # comment _must not_ contain the string "--".  See, for instance,
+    # here: https://www.w3.org/TR/REC-xml/#sec-comments
+    #
+    # And yet, in flagrant violation of this prohibition, this file
+    # sometimes contains comment tags that are opened via <!-- and
+    # closed via <!---->.  If left as they are, these incorrectly
+    # closed comment tags break the later tasks that use
+    # community.general.xml.
+    - name: Fix broken comment tags
+      ansible.builtin.replace:
+        path: /etc/xdg/xfce4/panel/default.xml
+        regexp: ^<!---->$
+        replace: -->
+
     - name: Check if there is an existing clock format node we can use
       community.general.xml:
         count: yes


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a task to correct certain malformed XML comment tags.

## 💭 Motivation and context ##

The file `/etc/xdg/xfce4/panel/default.xml` sometimes contains comment tags that are closed incorrectly.  In particular, a comment [_must not_ contain the string `--`](https://www.w3.org/TR/REC-xml/#sec-comments).

And yet, in flagrant violation of this prohibition, this file sometimes contains comment tags that are opened via `<!--` and closed
via `<!---->`.  If left as they are, these incorrectly closed comment tags break the later tasks that use `community.general.xml`.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.