### PR TITLE
Enhancement - Remove all transparency from default qterminal settings

### DIFF
--- a/files/qterminal.ini
+++ b/files/qterminal.ini
@@ -10,6 +10,6 @@ highlightCurrentTerminal=false
 HideTabBarWithOneTab=true
 
 [MainWindow]
-ApplicationTransparency=5
+ApplicationTransparency=0
 pos=@Point(200 100)
 size=@Size(640 480)


### PR DESCRIPTION
## 🗣 Description ##

The changes in this PR simply reduce the qterminal transparency setting from 5% to 0%. 

## 💭 Motivation and context ##

The reason I think this should be merged is that producing screenshots of semi-transparent terminals in debriefs and reports goes against many teams style guides due to unintended data leakage and muddiness that background applications can create. Users of the COOL environment are required to remove transparency before taking screenshots. 

## 🧪 Testing ##

I have tested this by installing the modified qterminal.ini file into a local instance of Kali with qterminal installed. 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.