### PR TITLE
Correctly enable user service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,7 +166,7 @@ repos:
           # necessary to add the ansible package itself as an
           # additional dependency, with the same pinning as is done in
           # requirements-test.txt of cisagov/skeleton-ansible-role.
-          # - ansible>=9,<10
+          - ansible>=9,<10
           # ansible-core 2.16.3 through 2.16.6 suffer from the bug
           # discussed in ansible/ansible#82702, which breaks any
           # symlinked files in vars, tasks, etc. for any Ansible role

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -56,16 +56,16 @@ def test_extra_files_do_not_exist(host, d, count):
     assert len(host.file(d).listdir()) == count
 
 
-# This test is commented out until #29 is resolved.
-# def test_symlink_exists(host):
-#     """Test that the file share symlink exists for the test user.
-
-#     Note that this test is dependent on the side_effect playbook being
-#     run.
-#     """
-#     f = host.file("/home/test/Desktop/share")
-#     assert f.exists
-#     assert f.is_symlink
-#     assert f.linked_to == "/share"
-#     assert f.user == "test"
-#     assert f.group == "test"
+def test_symlink_exists(host):
+    """Test that the file share symlink exists for the test user."""
+    share_symlink_location = "/home/test/Desktop/share"
+    f = host.file(share_symlink_location)
+    assert f.exists
+    assert f.is_symlink
+    assert f.linked_to == "/share"
+    # f.user and f.group return the user and group, respectively, of the
+    # symlink target.  I have to use stat because I want to actually check the
+    # user and group of the symlink itself.  See
+    # pytest-dev/pytest-testinfra#766 for more details.
+    assert host.check_output("stat --format %%U %s", share_symlink_location) == "test"
+    assert host.check_output("stat --format %%G %s", share_symlink_location) == "test"

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -24,7 +24,7 @@
     creates: /var/lib/systemd/linger/{{ username }}
   # This changed_when is necessary to pass idempotence.  We cannot use
   # the molecule-idempotence-notest tag here because the command must
-  # run; otherwise, the task the follows will fail.  See
+  # run; otherwise, the task that follows will fail.  See
   # ansible/molecule#2765 for more details.
   changed_when: false
 

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -15,6 +15,9 @@
 # This fiddling with linger does lead to some idempotence funkiness
 # for this role, so we have to make use of changed_when: false for
 # those two tasks.
+#
+# I run this task as root because if I run it as the actual user it
+# fails on Fedora.
 - name: Enable linger for user
   ansible.builtin.command:
     argv:
@@ -58,6 +61,9 @@
 
 # Now that the user-mode service has been enabled we can disable
 # linger for the user.
+#
+# I run this task as root because if I run it as the actual user it
+# fails on Fedora.
 - name: Disable linger for user
   ansible.builtin.command:
     argv:

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -44,8 +44,11 @@
       - enable-linger
       - "{{ username }}"
     creates: /var/lib/systemd/linger/{{ username }}
-  tags:
-    - molecule-idempotence-notest
+  # This changed_when is necessary to pass idempotence.  We cannot use
+  # the molecule-idempotence-notest tag here because the command must
+  # run; otherwise, the task the follows will fail.  See
+  # ansible/molecule#2765 for more details.
+  changed_when: false
 - name: >-
     Enable the user-mode systemd service that creates the file share symlink
     for the user
@@ -75,5 +78,8 @@
       - disable-linger
       - "{{ username }}"
     removes: /var/lib/systemd/linger/{{ username }}
-  tags:
-    - molecule-idempotence-notest
+  # This changed_when is necessary to pass idempotence.  We cannot use
+  # the molecule-idempotence-notest tag here because the command must
+  # run; otherwise, the user will needlessly have linger enabled.  See
+  # ansible/molecule#2765 for more details.
+  changed_when: false

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -4,16 +4,16 @@
     enabled: true
     name: systemd-logind
     state: started
-- name: >-
-    Add an environment variable necessary to make systemctl --user
-    commands work
-  ansible.builtin.lineinfile:
-    create: true
-    group: "{{ username }}"
-    line: export XDG_RUNTIME_DIR=/run/user/$(id --user)
-    mode: 0644
-    owner: "{{ username }}"
-    path: /home/{{ username }}/.bashrc
+# - name: >-
+#     Add an environment variable necessary to make systemctl --user
+#     commands work
+#   ansible.builtin.lineinfile:
+#     create: true
+#     group: "{{ username }}"
+#     line: export XDG_RUNTIME_DIR=/run/user/$(id --user)
+#     mode: 0644
+#     owner: "{{ username }}"
+#     path: /home/{{ username }}/.bashrc
 # This causes the user's user-specific systemd session to start on
 # boot instead of only when that user logs in.  We need the user's
 # session to be active so we can enable the user-mode systemd service,
@@ -55,13 +55,14 @@
     name: create-fileshare-symlink
     scope: user
   become: true
-  become_method: ansible.builtin.sudo
+  # become_flags: -H -S -n -i
+  become_method: community.general.sudosu
   become_user: "{{ username }}"
-  tags:
-    - molecule-notest
+  # tags:
+  #   - molecule-notest
   vars:
     # This is necessary to get around the difficult case where you ssh
-    # into a machine as an unprivileged user _and_ become an
+    # into a machine as an unprivileged user _and_ become a different
     # unprivileged user:
     # https://docs.ansible.com/ansible/latest/user_guide/become.html#risks-of-becoming-an-unprivileged-user
     ansible_ssh_pipelining: true

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -1,7 +1,7 @@
 ---
 # This is required before enabling or disabling linger.
 - name: Start and enable systemd-logind
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
     enabled: true
     name: systemd-logind
     state: started

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -27,6 +27,7 @@
   # run; otherwise, the task the follows will fail.  See
   # ansible/molecule#2765 for more details.
   changed_when: false
+
 - name: >-
     Enable the user-mode systemd service that creates the file share symlink
     for the user
@@ -44,6 +45,7 @@
     # unprivileged user:
     # https://docs.ansible.com/ansible/latest/user_guide/become.html#risks-of-becoming-an-unprivileged-user
     ansible_ssh_pipelining: true
+
 # Now that the user-mode service has been enabled we can disable
 # linger for the user.
 - name: Disable linger for user

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -52,7 +52,7 @@
 - name: >-
     Enable the user-mode systemd service that creates the file share symlink
     for the user
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     daemon_reload: true
     enabled: true
     name: create-fileshare-symlink

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -1,4 +1,5 @@
 ---
+# This is required before enabling or disabling linger.
 - name: Start and enable systemd-logind
   ansible.builtin.service:
     enabled: true
@@ -12,22 +13,8 @@
 # user-mode service, then disabling linger for the user.
 #
 # This fiddling with linger does lead to some idempotence funkiness
-# for this role, so we make use of the molecule-idempotence-notest
-# tag for those two tasks.
-#
-# The task that actually enables the user-mode systemd service can
-# succeed when run via Molecule, but as far as I can tell the only way
-# to make this work is to set "become" to "no" and set
-# "ansible_ssh_user" to "{{ username }}".  Unfortunately this
-# configuration cannot work when this role is used to build an AMI,
-# since in that case ssh connects via an AWS-generated ssh key that is
-# only valid for the AMI's default user.  Therefore we take the even
-# more drastic measure of applying the molecule-notest tag to this
-# task.
-#
-# TODO: Figure out a way to make the ansible.builtin.systemd task
-# succeed when run via molecule or when this Ansible role is used to
-# built an AMI.  See #29 for more details.
+# for this role, so we have to make use of changed_when: false for
+# those two tasks.
 - name: Enable linger for user
   ansible.builtin.command:
     argv:

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -4,16 +4,7 @@
     enabled: true
     name: systemd-logind
     state: started
-# - name: >-
-#     Add an environment variable necessary to make systemctl --user
-#     commands work
-#   ansible.builtin.lineinfile:
-#     create: true
-#     group: "{{ username }}"
-#     line: export XDG_RUNTIME_DIR=/run/user/$(id --user)
-#     mode: 0644
-#     owner: "{{ username }}"
-#     path: /home/{{ username }}/.bashrc
+
 # This causes the user's user-specific systemd session to start on
 # boot instead of only when that user logs in.  We need the user's
 # session to be active so we can enable the user-mode systemd service,
@@ -58,11 +49,8 @@
     name: create-fileshare-symlink
     scope: user
   become: true
-  # become_flags: -H -S -n -i
-  become_method: community.general.sudosu
+  become_method: ansible.builtin.sudo
   become_user: "{{ username }}"
-  # tags:
-  #   - molecule-notest
   vars:
     # This is necessary to get around the difficult case where you ssh
     # into a machine as an unprivileged user _and_ become a different

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -37,7 +37,17 @@
     name: create-fileshare-symlink
     scope: user
   become: true
-  become_method: ansible.builtin.sudo
+  # Using su (together with sudo, since we are not sshing in as the
+  # root user) to become the user causes an actual systemd session to
+  # be created for the user.  This in turn causes the user's systemd
+  # user services to be started, which we require for our Molecule
+  # tests.
+  #
+  # sudosu also seems to be required for this task on Kali Linux.  If
+  # I use sudo then the task "succeeds" but the service does not
+  # actually get enabled, and if I use su by itself then the task
+  # hangs due to a prompt for credentials.
+  become_method: community.general.sudosu
   become_user: "{{ username }}"
   vars:
     # This is necessary to get around the difficult case where you ssh

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -6,6 +6,18 @@
     name: systemd-logind
     state: started
 
+# Kali Linux, at least, currently has an issue where systemd-logind is
+# not restarted after an update and is left in a non-functional state.
+# This results in an inability to create a user systemd session, which
+# is necessary when interacting with systemd user services, so we
+# force a restart here.
+- name: Restart systemd-logind
+  ansible.builtin.systemd_service:
+    name: systemd-logind
+    state: restarted
+  # This is necessary to preserve idempotence.
+  changed_when: false
+
 # This causes the user's user-specific systemd session to start on
 # boot instead of only when that user logs in.  We need the user's
 # session to be active so we can enable the user-mode systemd service,

--- a/tasks/enable_file_share_service.yml
+++ b/tasks/enable_file_share_service.yml
@@ -17,7 +17,7 @@
 # those two tasks.
 #
 # I run this task as root because if I run it as the actual user it
-# fails on Fedora.
+# fails on Fedora, presumably due to SELinux limitations.
 - name: Enable linger for user
   ansible.builtin.command:
     argv:
@@ -40,7 +40,7 @@
     name: create-fileshare-symlink
     scope: user
   become: true
-  # Using su (together with sudo, since we are not sshing in as the
+  # Using su (together with sudo, since we may not be sshing in as the
   # root user) to become the user causes an actual systemd session to
   # be created for the user.  This in turn causes the user's systemd
   # user services to be started, which we require for our Molecule
@@ -63,7 +63,7 @@
 # linger for the user.
 #
 # I run this task as root because if I run it as the actual user it
-# fails on Fedora.
+# fails on Fedora, presumably due to SELinux limitations.
 - name: Disable linger for user
   ansible.builtin.command:
     argv:


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to enable the user `systemd` service in a way that works when creating AMIs and when testing via `molecule`.

## 💭 Motivation and context ##

These changes resolve #29.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.