### PR TITLE
Cease excluding ARM64 platforms from Molecule testing where possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,20 +184,6 @@ jobs:
         architecture:
           - amd64
           - arm64
-        exclude:
-          # Starting with version 256 of systemd, the systemd-logind
-          # service does not appear to start up under QEMU.  This is
-          # fatal for this Ansible role.
-          #
-          # We still support these platforms, but we can't test them
-          # until we have native ARM64 runners.  See issue #59 for
-          # more details.
-          - architecture: arm64
-            platform: debian13-systemd
-          - architecture: arm64
-            platform: kali-systemd
-          - architecture: arm64
-            platform: fedora41-systemd
         platform:
           # Amazon Linux 2023 does not currently offer Xfce:
           # https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-al2023-20230419.html


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the exclusion of ARM64 platforms from Molecule testing where possible.

## 💭 Motivation and context ##

In many cases we no longer need to do this because we are now using native ARM64 GitHub Actions runners.

Resolves #59.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
